### PR TITLE
refactor: rewrote the main components to showcase react styling

### DIFF
--- a/app/old/page.tsx
+++ b/app/old/page.tsx
@@ -1,0 +1,11 @@
+import { DayScheduler } from "../../components/Day Scheduler";
+
+export default function Home() {
+    return (
+        <main className="flex flex-row w-full min-h-screen h-full items-center justify-between bg-red-500">
+            <div className="flex flex-col z-10 w-full h-screen items-center justify-between font-mono text-sm lg:flex bg-blue-500">
+                <DayScheduler />
+            </div>
+        </main>
+    )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,10 @@
-import { DayScheduler } from "@/components/Day Scheduler";
+import DayScheduler from "../components/DayScheduler";
 
 export default function Home() {
   return (
     <main className="flex flex-row w-full min-h-screen h-full items-center justify-between bg-red-500">
       <div className="flex flex-col z-10 w-full h-screen items-center justify-between font-mono text-sm lg:flex bg-blue-500">
-        
         <DayScheduler />
-
       </div>
     </main>
   )

--- a/components/Day Scheduler/components/Slot/index.tsx
+++ b/components/Day Scheduler/components/Slot/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Status } from "@/types/dist";
+import { Status } from "../../../../types/scheduler";
 
 export const Slot = ({ title, color, header, footer }: {
     title: string,
@@ -15,7 +15,7 @@ export const Slot = ({ title, color, header, footer }: {
     const backgroundColor = color as string;
     return (
         <>
-            
+
             {/* Single Appointment (full rounded) */}
             {
                 header && footer &&
@@ -55,7 +55,7 @@ export const Slot = ({ title, color, header, footer }: {
                 !header && footer &&
                 <>
                     <div className={`flex flex-row justify-start w-5/6 h-20 bg-${backgroundColor}-200 rounded-b-2xl`}>
-                        
+
                     </div>
                 </>
             }
@@ -71,4 +71,16 @@ export const Slot = ({ title, color, header, footer }: {
             }
         </>
     )
+}
+
+function getColorStyle(status: Status) {
+    switch (status) {
+        case Status.Red:
+        case Status.Orange:
+        case Status.Yellow:
+        case Status.Blue:
+        case Status.Green:
+        case Status.Empty:
+        default: return "";
+    }
 }

--- a/components/Day Scheduler/index.tsx
+++ b/components/Day Scheduler/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect, MouseEvent } from "react";
-import { Status } from "@/types/dist";
+import { Status } from "../../types/scheduler";
 import { X, Trash2, Clock, MapPin, AlignLeft, CalendarCheck } from 'lucide-react';
 import { Slot } from "./components/Slot";
 
@@ -8,9 +8,9 @@ export const DayScheduler = () => {
     interface Appointment {
         title: string
         start: string,
-        end: string, 
-        location: string, 
-        description: string, 
+        end: string,
+        location: string,
+        description: string,
     }
     const NULL_APPOINTMENT_KEY = "NULL";
 
@@ -66,7 +66,7 @@ export const DayScheduler = () => {
         e.preventDefault();
 
         const slot = slots[key];
-        
+
         // check if slot is occupied
         if (slots[key].status == Status.Empty) {
             const startTime = times[key];
@@ -99,7 +99,7 @@ export const DayScheduler = () => {
             const endTime = appointment.end;
             const startIndex = times.indexOf(startTime);
             const endIndex = times.indexOf(endTime);
-            
+
             // loop through each slot index and set
             // slot status to active color
             let updatedSlots = slots;
@@ -116,7 +116,7 @@ export const DayScheduler = () => {
     const addAppointment = (appointment: { [appointmentKey: string]: Appointment }) => {
         const startTime = Object.keys(appointment)[0]; // Extract the start time from the keys of the appointment object
         const appointmentContent = appointment[startTime];
-        
+
         // update the slot statuses
         const startIndex = times.indexOf(appointment[startTime].start);
         const endIndex = times.indexOf(appointment[startTime].end);
@@ -127,13 +127,13 @@ export const DayScheduler = () => {
             updatedSlots[i].appointmentKey = startTime;
         }
         setSlots(updatedSlots);
-    
+
         // Create a new copy of the appointments object with the new appointment added
         const updatedAppointments = {
             ...state.appointments,
             ...appointment,
         };
-    
+
         setState({
             ...state,
             appointments: updatedAppointments,
@@ -155,10 +155,10 @@ export const DayScheduler = () => {
         setSelectedLocation(data.location);
         setSelectedDescription(data.description);
     }
-     
+
     const clearSelectedAppointment = () => {
         if (!selected) return;
-        setSelected({title: '', start: '', end: '', location: '', description: ''});
+        setSelected({ title: '', start: '', end: '', location: '', description: '' });
     }
 
     const deleteSelectedAppointment = () => {
@@ -261,7 +261,7 @@ export const DayScheduler = () => {
     return (
         <>
             <div className="flex flex-row w-full h-full bg-black">
-                
+
                 <div className="flex flex-col w-1/2 h-full bg-white">
                     <div className="w-full h-full overflow-y-scroll no-scrollbar">
                         {
@@ -269,7 +269,7 @@ export const DayScheduler = () => {
                                 const slot = slots[index];
 
                                 // TODO: kinda scuffed code
-                                let appointmentKey, appointment, startTime, endTime;
+                                let appointmentKey, appointment: Appointment, startTime, endTime;
                                 if (slot.status != Status.Empty) {
                                     appointmentKey = slot.appointmentKey;
                                     appointment = state.appointments[appointmentKey];
@@ -283,58 +283,58 @@ export const DayScheduler = () => {
                                 }
 
                                 return (
-                                    <button 
-                                        className="flex flex-row justify-start items-start w-full h-24 p-5 gap-5 white" 
+                                    <button
+                                        className="flex flex-row justify-start items-start w-full h-24 p-5 gap-5 white"
                                         onClick={(e) => handleAppointment(e, index)} key={index}
                                     >
-                                        <h1>{time}</h1> 
+                                        <h1>{time}</h1>
                                         {
-                                            slot.status != Status.Empty ? 
-                                            (
+                                            slot.status != Status.Empty ?
+                                                (
 
-                                                // single appointment (full rounded)
-                                                time == startTime && time == endTime ? 
-                                                (   
-                                                    <Slot 
-                                                        title={appointment!.title}
-                                                        color={slot.status}
-                                                        header
-                                                        footer
-                                                    />
-                                                ) : (
-
-                                                    // header
-                                                    time == startTime ? 
-                                                    (
-                                                        <Slot 
-                                                            title={appointment!.title}
-                                                            color={slot.status}
-                                                            header
-                                                        />
-                                                    ) : (
-
-                                                        // footer
-                                                        time == endTime ? 
+                                                    // single appointment (full rounded)
+                                                    time == startTime && time == endTime ?
                                                         (
-                                                            <Slot 
+                                                            <Slot
                                                                 title={appointment!.title}
                                                                 color={slot.status}
+                                                                header
                                                                 footer
                                                             />
-                                                        ) : 
+                                                        ) : (
 
-                                                        // body
-                                                        (
-                                                            <Slot 
-                                                                title={appointment!.title}
-                                                                color={slot.status}
-                                                            />
+                                                            // header
+                                                            time == startTime ?
+                                                                (
+                                                                    <Slot
+                                                                        title={appointment!.title}
+                                                                        color={slot.status}
+                                                                        header
+                                                                    />
+                                                                ) : (
+
+                                                                    // footer
+                                                                    time == endTime ?
+                                                                        (
+                                                                            <Slot
+                                                                                title={appointment!.title}
+                                                                                color={slot.status}
+                                                                                footer
+                                                                            />
+                                                                        ) :
+
+                                                                        // body
+                                                                        (
+                                                                            <Slot
+                                                                                title={appointment!.title}
+                                                                                color={slot.status}
+                                                                            />
+                                                                        )
+
+                                                                )
                                                         )
 
-                                                    )
-                                                )
-
-                                            ) : (<></>)
+                                                ) : (<></>)
                                         }
                                     </button>
                                 )
@@ -349,28 +349,28 @@ export const DayScheduler = () => {
                             <>
 
                                 <div className="flex flex-row justify-between items-center w-full h-24 px-5">
-                                    <X className="cursor-pointer" onClick={clearSelectedAppointment}/>
-                                    <input 
+                                    <X className="cursor-pointer" onClick={clearSelectedAppointment} />
+                                    <input
                                         className="w-1/2 h-12 bg-gray-200 border-b-gray-500 border-b-2 text-gray-500 text-lg font-bold p-3 focus:outline-none"
                                         onChange={(e) => setSelectedTitle(e.target.value)}
                                         value={selectedTitle}
                                     />
-                                    <Trash2 className="cursor-pointer" onClick={deleteSelectedAppointment}/>
+                                    <Trash2 className="cursor-pointer" onClick={deleteSelectedAppointment} />
                                 </div>
 
                                 <div className="flex flex-col w-full h-full px-24 py-10 gap-10">
                                     <div className="flex flex-row items-center w-full h-16 gap-4">
                                         <Clock />
-                                        <input 
-                                            className="flex text-center w-1/4 h-full rounded-2xl focus:outline-none" 
+                                        <input
+                                            className="flex text-center w-1/4 h-full rounded-2xl focus:outline-none"
                                             placeholder={selected.start}
                                             onChange={(e) => setSelectedStartTime(e.target.value)}
                                             value={selectedStartTime}
                                         />
                                         <h1>to</h1>
-                                        <input 
+                                        <input
                                             className="flex text-center w-1/4 h-full rounded-2xl focus:outline-none"
-                                            placeholder={selected.end} 
+                                            placeholder={selected.end}
                                             onChange={(e) => setSelectedEndTime(e.target.value)}
                                             value={selectedEndTime}
                                         />
@@ -378,7 +378,7 @@ export const DayScheduler = () => {
 
                                     <div className="flex flex-row items-center w-full h-16 gap-4">
                                         <MapPin />
-                                        <input 
+                                        <input
                                             className="flex w-full h-full rounded-2xl p-8 focus:outline-none"
                                             placeholder={selected.location}
                                             onChange={(e) => setSelectedLocation(e.target.value)}
@@ -388,7 +388,7 @@ export const DayScheduler = () => {
 
                                     <div className="flex flex-row items-start w-full h-16 gap-4">
                                         <AlignLeft />
-                                        <input 
+                                        <input
                                             className="flex w-full h-full rounded-2xl p-8 focus:outline-none"
                                             placeholder={selected.description}
                                             onChange={(e) => setSelectedDescription(e.target.value)}
@@ -401,7 +401,7 @@ export const DayScheduler = () => {
                                         <button>Cancel</button>
                                     </div>
                                 </div>
-                            
+
                             </>
                         ) : (
                             <>
@@ -427,12 +427,12 @@ export const DayScheduler = () => {
                                         </button>
                                     </div>
                                 </div>
-                            
+
                             </>
                         )
                     }
                 </div>
-            
+
             </div>
         </>
     )

--- a/components/DayScheduler.tsx
+++ b/components/DayScheduler.tsx
@@ -1,0 +1,288 @@
+'use client'
+//using immutable to help with not causing state side affects with updating state
+// spread operator doesn't work if spreading reference types (anything outside a primitive)
+import { Map as ImmutableMap } from "immutable";
+import { useState } from "react";
+import { Appointment, SlotState, Status } from "../types/scheduler";
+import Slot from "./Slot";
+import { isNull, notNull } from "../utilities";
+import { AlignLeft, CalendarCheck, Clock, MapPin, Trash2, X } from "lucide-react";
+
+const times = [
+    "0:00",
+    "0:30",
+    "1:00",
+    "1:30",
+    "2:00",
+    "2:30",
+    "3:00",
+    "3:30",
+    "4:00",
+    "4:30",
+    "5:00",
+    "5:30",
+];
+
+const DEFAULT_APP: Appointment = {
+    title: "Title",
+    start: "",
+    end: "",
+    location: "",
+    description: "",
+};
+
+// personal taste here, I prefer the use of `function Name: return type {}` instead of `const Name = () => {}`
+// there isn't much overhead with the use of function vs a lambda function (only the binding of `this`)
+// I also like to specify specifically the return type of a function to make sure I don't accidentally miss a return
+export default function DayScheduler(): JSX.Element {
+    /*
+        instead of using an array in addition to trying to index into a slot and hopping the order doesn't change,
+        just use a map so you can index directly into the slot state.
+    */
+    const [slots, setSlots] = useState<ImmutableMap<string, SlotState>>(ImmutableMap(times.map(time => ([time, {
+        status: Status.Empty,
+    }]))));
+
+    const [selectedApp, setSelectedApp] = useState<Appointment>();
+    const [state, setState] = useState<ImmutableMap<string, Appointment>>(ImmutableMap());
+
+    function onSlotClick(time: string) {
+        const slot = slots.get(time)!;
+        // if we don't have an appointment set in this slot, lets make one.
+        if (slot.status === Status.Empty) {
+            const index = times.indexOf(time);
+            // TODO: discuss why you are using beginning time if we chose the end, I would expect to set end time to the start time.
+            // seems like edge case of selecting 5:30 causes problems. Might make it so 5:30 can't be a start time?
+            // changed to current time to indicate that block and that block only since that is what makes the most sense.
+            let end = index !== -1 || index !== times.length - 1 ? times[index + 1]! : time!;// times[0]!;
+            // if the block after is already committed to an appointment, default this one to
+            end = slots.get(end)!.status !== Status.Empty ? time : end;
+            const newApp: Appointment = {
+                ...DEFAULT_APP,
+                start: time,
+                end,
+            }
+            // important: I am making new objects for both sets to ensure that they don't
+            // both reference the same object. (this could lead to side affects if you accidentally modify the state in either reference)
+            // this usually isn't a problem as long as functions don't violate react hook rules, but its pretty easy to accidentally do.
+            // so I am doing it deliberately so I have a chance to explain it.
+            setSelectedApp({ ...newApp });
+            setState(state.set(time, { ...newApp }));
+            // utilizing the benefits of immutable allowing us to set the statuses.
+            // it returns new map so we don't have to worry about side affects due to ref types.
+            // otherwise using normal map i would have had to make a new map then modify that.
+            setSlots(slots
+                .set(time, { status: Status.Orange, appointmentKey: time })
+                .set(end, { status: Status.Orange, appointmentKey: time }));
+        } else {
+            const app = state.get(time);
+            if (app == undefined) {
+                console.warn("selected a slot whose status indicates it has an appointment but no appointment was found");
+                return;
+            } else setSelectedApp({ ...app });
+        }
+    }
+
+    function onTrayUseDay() {
+        //TODO implement behavior
+    }
+
+    function onTraySave() {
+        // TODO: implement behavior
+    }
+
+    function onAppDelete() {
+        if (isNull(selectedApp)) return;
+
+        const startIndex = times.indexOf(selectedApp.start);
+        const endIndex = times.indexOf(selectedApp.end);
+        let newSlots = slots;
+        // technically this will "set" twice if start and end are the same time but eh not a big concern
+        for (let i = startIndex; i <= endIndex; i++) {
+            // don't try to set a slot for -1, means no start. this is probably a bug
+            // so log a warning
+            if (i === -1) {
+                console.warn(`Appointment: ${selectedApp.start} has negative index for delete: ${selectedApp.start}: ${startIndex}, ${selectedApp.end}: ${endIndex}`);
+                continue;
+            }
+            const time = times[i];
+            newSlots = newSlots.set(time, { status: Status.Empty });
+        }
+        // update the slots
+        setSlots(newSlots);
+        setSelectedApp(undefined);
+        setState(state.remove(selectedApp.start));
+    }
+
+    function onAppUpdate(update: Appointment) {
+        if (isNull(selectedApp)) return;
+
+        const oldStartIndex = times.indexOf(selectedApp.start);
+        const newStartIndex = times.indexOf(update.start);
+        const startIndex = oldStartIndex < newStartIndex ? oldStartIndex : newStartIndex;
+
+        const oldEndIndex = times.indexOf(selectedApp.end);
+        const newEndIndex = times.indexOf(update.end);
+        const endIndex = oldEndIndex > newEndIndex ? oldEndIndex : newEndIndex;
+
+
+        let newSlots = slots;
+        // technically this will "set" twice if start and end are the same time but eh not a big concern
+        for (let i = startIndex; i <= endIndex; i++) {
+            // don't try to set a slot for -1, means no start. this is probably a bug
+            // so log a warning
+            if (i === -1) {
+                console.warn(`Appointment: ${selectedApp.start} has negative index for delete: ${selectedApp.start}: ${startIndex}, ${selectedApp.end}: ${endIndex}`);
+                continue;
+            }
+            const time = times[i];
+            newSlots = newSlots.set(time, i < newStartIndex || i > newEndIndex ? { status: Status.Empty } : { status: Status.Orange, appointmentKey: update.start });
+        }
+
+        setSlots(newSlots);
+        setSelectedApp(undefined); // may not want to deselect on update 🤷‍♂️ if so remove this line
+        setState(state.set(update.start, { ...update }));
+    }
+
+    return (
+        <>
+            <div className="flex flex-row w-full h-full bg-black">
+                <div className="flex flex-col w-1/2 h-full bg-white">
+                    <div className="w-full h-full overflow-y-scroll no-scrollbar">
+                        {slots.toArray().sort().map(([time, slotState]) => {
+                            const app = notNull(slotState.appointmentKey) ? state.get(slotState.appointmentKey) : undefined;
+                            //instead of a confusing ternary operator, move the conditional to the component so its easier to read what is actually happening
+                            // again, we identifying what actually needs to be be conditional and limiting the complexity of our branching logic.
+                            return (
+                                <button
+                                    className="flex flex-row justify-start items-start w-full h-24 p-5 gap-5 white border-dashed border-black border-y border-collapse"
+                                    onClick={() => onSlotClick(time)}
+                                    key={time}
+                                >
+                                    <h1>{time}</h1>
+                                    <Slot status={slotState.status} header={time === app?.start} footer={time === app?.end} title={app?.title} />
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+                <div className="flex flex-col justify-start items-start w-1/2 h-full bg-gray-200 p-3">
+                    {notNull(selectedApp) ?
+                        <EditTray
+                            app={selectedApp}
+                            onDeselect={() => setSelectedApp(undefined)}
+                            onDelete={onAppDelete}
+                            onSave={onAppUpdate}
+                        /> :
+                        <DefaultTray onUseDate={onTrayUseDay} onSave={onTraySave} />
+                    }
+                </div>
+            </div>
+        </>
+    );
+}
+
+interface EditTrayProps {
+    app: Appointment,
+    onDeselect: () => void,
+    onDelete: () => void,
+    onSave: (app: Appointment) => void
+}
+
+function EditTray({ app, onDeselect, onDelete, onSave }: EditTrayProps): JSX.Element {
+    const [title, setTitle] = useState(app.title);
+    const [start, setStart] = useState(app.start);
+    const [end, setEnd] = useState(app.end);
+    const [description, setDescription] = useState(app.description);
+    const [location, setLocation] = useState(app.location);
+
+    /*
+      TODO: input validation should probably happen to make sure the times are valid times.
+      could do some sort of autocomplete system or do a select/dropdown to select a time.
+
+      should also make sure you don't allow selecting an end time before the start time.
+
+      you could do validation on the "onSave" onClick and display an invalid message with the issue
+      just some thoughts.
+      another validation would be to make sure you don't overlap an existing appointment since that isn't supported currently.
+     */
+
+    return (
+        <>
+            <div className="flex flex-row justify-between items-center w-full h-24 px-5">
+                <X className="cursor-pointer" onClick={onDeselect} />
+                <input
+                    className="w-1/2 h-12 bg-gray-200 border-b-gray-500 border-b-2 text-gray-500 text-lg font-bold p-3 focus:outline-none"
+                    onChange={e => setTitle(e.currentTarget.value)}
+                    value={title}
+                />
+                <Trash2 className="cursor-pointer" onClick={onDelete} />
+            </div>
+            <div className="flex flex-col w-full h-full px-24 py-10 gap-10">
+                <div className="flex flex-row items-center w-full h-16 gap-4">
+                    <Clock />
+                    <input
+                        className="flex text-center w-1/4 h-full rounded-2xl focus:outline-none"
+                        onChange={e => setStart(e.currentTarget.value)}
+                        value={start}
+                    />
+                    <h1>to</h1>
+                    <input
+                        className="flex text-center w-1/4 h-full rounded-2xl focus:outline-none"
+                        onChange={e => setEnd(e.currentTarget.value)}
+                        value={end}
+                    />
+                </div>
+                <div className="flex flex-row items-center w-full h-16 gap-4">
+                    <MapPin />
+                    <input
+                        className="flex w-full h-full rounded-2xl p-8 focus:outline-none"
+                        onChange={e => setLocation(e.currentTarget.value)}
+                        value={location}
+                    />
+                </div>
+
+                <div className="flex flex-row items-start w-full h-16 gap-4">
+                    <AlignLeft />
+                    <input
+                        className="flex w-full h-full rounded-2xl p-8 focus:outline-none"
+                        onChange={e => setDescription(e.currentTarget.value)}
+                        value={description}
+                    />
+                </div>
+
+                <div className="flex flex-row justify-evenly items-center w-full h-16 gap-4">
+                    <button onClick={() => onSave({
+                        description,
+                        end,
+                        location,
+                        start,
+                        title
+                    })}>Save</button>
+                    <button onClick={onDeselect}>Cancel</button>
+                </div>
+            </div>
+        </>
+    );
+}
+
+function DefaultTray({ onUseDate, onSave }: { onUseDate: () => void, onSave: () => void }): JSX.Element {
+    return (
+        <>
+            <div className="flex flex-col justify-center items-center text-center font-light text-gray-600 gap-16 w-full h-full">
+                <div className="flex flex-col">
+                    <CalendarCheck size={256} color="gray" />
+                    <h1>Schedule your day, or bring <br /> in a pre-made template!</h1>
+                </div>
+                <div className="flex flex-row justify-evenly items-center gap-5">
+                    <button className="bg-orange-300 text-white text-xl font-bold uppercase rounded-2xl py-3 px-5" onClick={onUseDate}>
+                        Use Day
+                    </button>
+                    <button className="bg-white text-gray-600 text-xl font-bold uppercase rounded-2xl py-3 px-8" onClick={onSave}>
+                        Save
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/components/Slot.tsx
+++ b/components/Slot.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { Status } from "../types/scheduler";
+
+// one of the only exceptions to putting all types in the types folder.
+// react props are usually kept above the function declaration.
+export interface SlotProps {
+    title?: string;
+    status: Status;
+    header?: boolean;
+    footer?: boolean;
+}
+
+// typically its one component per file so the component is marked as the default export.
+// assigning values to nullable fields so they always have a value.
+export default function Slot({ title = "", status, header = false, footer = false }: SlotProps): JSX.Element | null {
+    if (status === Status.Empty) return null;
+    // get the background color, allow tailwind to import the color.
+    const [titleColor, bodyColor] = getColorStyle(status);
+    const rounding = header ? "rounded-t-2xl" : footer ? "rounded-b-2xl" : "";
+    const height = !footer ? "h-24" : "h-20";
+    // by targeting the specific things that change in the component it makes it easier to shrink the complexity of the code
+    // and improve readability (also helps remove bugs related to needing to copy paste and update 4 places)
+    return (
+        // TODO: test if the changing between h-20 and h-24 is needed I think its just a typo and all should be one or the other.
+        <div className={`w-5/6 ${height} self-start ${rounding} ${!header ? bodyColor : ""}`}>
+            {header &&
+                <>
+                    <div className={`flex flex-row justify-start w-full h-1/5 ${titleColor} ${rounding}`} >
+                        <h1 className="text-white font-bold px-5">{title}</h1>
+                    </div>
+                    <div className={`w-full h-4/5 ${bodyColor} ${footer ? "rounded-b-2xl" : ""}`}></div>
+                </>
+            }
+        </div>
+    );
+}
+
+/**
+ * get the tailwind css color for a given status.
+ *
+ * NOTE: doing this to ensure tailwind knows at build time css classes.
+ *
+ * @param status status to get color for
+ * @returns tailwind css for background color
+ */
+function getColorStyle(status: Status): [title: string, body: string] {
+    switch (status) {
+        case Status.Red: return ["bg-red-800", "bg-red-200"];
+        case Status.Orange: return ["bg-orange-800", "bg-orange-200"];
+        case Status.Yellow: return ["bg-yellow-800", "bg-yellow-200"];
+        case Status.Blue: return ["bg-blue-800", "bg-blue-200"];
+        case Status.Green: return ["bg-green-800", "bg-green-200"];
+        case Status.Empty:
+        default: return ["", ""];
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "18.2.6",
     "autoprefixer": "10.4.14",
     "clsx": "^2.0.0",
+    "immutable": "^4.3.1",
     "lucide-react": "^0.259.0",
     "next": "13.4.9",
     "next-auth": "^4.22.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   clsx:
     specifier: ^2.0.0
     version: 2.0.0
+  immutable:
+    specifier: ^4.3.1
+    version: 4.3.1
   lucide-react:
     specifier: ^0.259.0
     version: 0.259.0(react@18.2.0)
@@ -467,6 +470,10 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: false
+
+  /immutable@4.3.1:
+    resolution: {integrity: sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A==}
     dev: false
 
   /inflight@1.0.6:

--- a/types/dist.ts
+++ b/types/dist.ts
@@ -1,8 +1,0 @@
-export enum Status {
-    Empty = "empty",
-    Red = "red",
-    Orange = "orange",
-    Yellow = "yellow",
-    Blue = "blue",
-    Green = "green",  
-}

--- a/types/scheduler.ts
+++ b/types/scheduler.ts
@@ -1,0 +1,20 @@
+export interface Appointment {
+    title: string,
+    start: string,
+    end: string,
+    location: string,
+    description: string,
+}
+export interface SlotState {
+    status: Status,
+    appointmentKey?: string;
+}
+
+export enum Status {
+    Empty = "empty",
+    Red = "red",
+    Orange = "orange",
+    Yellow = "yellow",
+    Blue = "blue",
+    Green = "green",
+}

--- a/utilities/index.ts
+++ b/utilities/index.ts
@@ -1,0 +1,23 @@
+/**
+ * a helpful function to assert that an item is not null
+ *
+ * @see isNull - complement function
+ *
+ * @param item item to check
+ * @returns if item is not null
+ */
+export function notNull<T>(item: T | undefined | null): item is T {
+    return item !== undefined && item !== null;
+}
+
+/**
+ * a helpful function to asset that an item is undefined or null
+ *
+ * @see notNull - complement function
+ *
+ * @param item item to check
+ * @returns if item is null or undefined
+ */
+export function isNull<T>(item: T | undefined | null): item is undefined | null {
+    return item == undefined || item == null;
+}


### PR DESCRIPTION
I focused on the main two components `DayScheduler` and `Slot`.

In terms of folder structure what I usually do is to do root level folders based on content:

root
  |-> utlities - keep helper functions here
  |-> components - keep all resuable components here. Components typically use TitleCase for file name since components should be named TitleCase. You usually only have one component per file so you make it the default export. using the TitleCase file name ensures it imports in the same format as a default export.
  |-> api - i usually put all my networking code here
  |-> pages/app - here lives all my pages or app pages (depending on framework you are using)
  |-> types - I use this to store all interfaces and enums that aren't component props.


let me know if you want to hop in a discord call to discuss some of the changes. (some of them are definitely personal preferences). It was a lot of changes 😅